### PR TITLE
Bugfix for USB drivers that don't report the proc name as usb-storage.

### DIFF
--- a/libraries/Bmbackup.php
+++ b/libraries/Bmbackup.php
@@ -485,7 +485,7 @@ class Bmbackup extends Engine
             //$proc_name = file_get_contents("$usb_storage/proc_name");
             $proc_name = stream_get_contents($fh, -1);
 
-            if (trim($proc_name) <> "usb-storage") {
+	        if ((trim($proc_name) <> "usb-storage") && (trim($proc_name) <> "(null)")) {
                 clearos_log("bmbackup", "skipping because proc_name NON EQUAL TO 'usb-storage': " . $proc_name);
                 continue;
             }


### PR DESCRIPTION
There are quite a few people, myself included, who can't use the BMBackup script due to a USB drive not showing up in the list.
Here are some examples:
https://www.clearos.com/clearfoundation/social/community/usb-sata-disk-cradle-is-not-showing-in-bmbackup
https://www.clearos.com/clearfoundation/social/community/not-seeing-usb-drive
https://www.clearos.com/clearfoundation/social/community/usb-drive-not-visible

This change is minimal, and works for me with a seagate USB device on a ProLiant Gen10 server, running the latest ClearOS 7 OS.